### PR TITLE
Update PublicationXref editing

### DIFF
--- a/modules/org.pathvisio.core/src/org/pathvisio/core/biopax/BiopaxNode.java
+++ b/modules/org.pathvisio.core/src/org/pathvisio/core/biopax/BiopaxNode.java
@@ -60,9 +60,11 @@ public class BiopaxNode
 		List<BiopaxProperty> existingProps = getProperties(p.getName());
 		if(p.getMaxCardinality() != BiopaxProperty.UNBOUND &&
 				existingProps.size() >= p.getMaxCardinality()) {
-			//Replace the first occuring property
+			//Replace other properties with the same name
 			int first = getFirstPropertyIndex(p.getName());
-			properties.remove(first);
+			for(BiopaxProperty existingProp : existingProps) {
+				removeProperty(existingProp);
+			}
 			properties.add(first, p);
 		} else {
 			properties.add(p);

--- a/modules/org.pathvisio.core/src/org/pathvisio/core/biopax/PublicationXref.java
+++ b/modules/org.pathvisio.core/src/org/pathvisio/core/biopax/PublicationXref.java
@@ -80,13 +80,20 @@ public class PublicationXref extends BiopaxNode {
 		setPropertyValue(PropertyType.YEAR, year);
 	}
 
+	public String getDb() {
+		return getPropertyValue(PropertyType.DB);
+	}
+
+	public void setDb(String db) {
+		setPropertyValue(PropertyType.DB, db);
+	}
+
 	public String getPubmedId() {
 		return getPropertyValue(PropertyType.ID);
 	}
 
 	public void setPubmedId(String id) {
 		setPropertyValue(PropertyType.ID, id);
-		setPropertyValue(PropertyType.DB, "PubMed");
 	}
 
 	public List<String> getAuthors() {

--- a/modules/org.pathvisio.core/src/org/pathvisio/core/biopax/PublicationXref.java
+++ b/modules/org.pathvisio.core/src/org/pathvisio/core/biopax/PublicationXref.java
@@ -85,7 +85,7 @@ public class PublicationXref extends BiopaxNode {
 	}
 
 	public void setDb(String db) {
-		setPropertyValue(PropertyType.DB, db);
+		setPropertyValue(PropertyType.DB, db.equals("") ? "NA" : db);
 	}
 
 	public String getPubmedId() {
@@ -93,7 +93,7 @@ public class PublicationXref extends BiopaxNode {
 	}
 
 	public void setPubmedId(String id) {
-		setPropertyValue(PropertyType.ID, id);
+		setPropertyValue(PropertyType.ID, id.equals("") ? "NA" : id);
 	}
 
 	public List<String> getAuthors() {

--- a/modules/org.pathvisio.core/src/org/pathvisio/core/model/GpmlFormat2013a.java
+++ b/modules/org.pathvisio.core/src/org/pathvisio/core/model/GpmlFormat2013a.java
@@ -844,9 +844,6 @@ class GpmlFormat2013a extends GpmlFormatAbstract implements GpmlFormatReader, Gp
 		for (Element e : elementList) {
 			// make sure biopax references are sorted alphabetically by rdf-id 
 			if(e.getName().equals("Biopax")) {
-				for(Element e3 : e.getChildren()) {
-					e3.removeChildren("AUTHORS", GpmlFormat.BIOPAX);
-				}
 				e.sortChildren(new BiopaxAttributeComparator());
 			}
 			root.addContent(e);

--- a/modules/org.pathvisio.gui/src/org/pathvisio/gui/dialogs/PublicationXRefDialog.java
+++ b/modules/org.pathvisio.gui/src/org/pathvisio/gui/dialogs/PublicationXRefDialog.java
@@ -108,7 +108,9 @@ public class PublicationXRefDialog extends OkCancelDialog {
 	}
 
 	protected void okPressed() {
-		input.setDb(DB_OPTIONS[db.getSelectedIndex()]);
+		if (db.getSelectedIndex() > -1) {
+			input.setDb(DB_OPTIONS[db.getSelectedIndex()]);
+		}
 		input.setPubmedId(pmId.getText().trim());
 		input.setTitle(title.getText());
 		input.setSource(source.getText());

--- a/modules/org.pathvisio.gui/src/org/pathvisio/gui/dialogs/PublicationXRefDialog.java
+++ b/modules/org.pathvisio.gui/src/org/pathvisio/gui/dialogs/PublicationXRefDialog.java
@@ -108,9 +108,7 @@ public class PublicationXRefDialog extends OkCancelDialog {
 	}
 
 	protected void okPressed() {
-		if (db.getSelectedIndex() > -1) {
-			input.setDb(DB_OPTIONS[db.getSelectedIndex()]);
-		}
+		input.setDb((String) db.getSelectedItem());
 		input.setPubmedId(pmId.getText().trim());
 		input.setTitle(title.getText());
 		input.setSource(source.getText());

--- a/modules/org.pathvisio.gui/src/org/pathvisio/gui/dialogs/PublicationXRefDialog.java
+++ b/modules/org.pathvisio.gui/src/org/pathvisio/gui/dialogs/PublicationXRefDialog.java
@@ -27,6 +27,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.swing.JButton;
+import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -58,14 +59,17 @@ public class PublicationXRefDialog extends OkCancelDialog {
 
 	final static String ADD = "Add";
 	final static String REMOVE = "Remove";
-	final static String PMID = "Pubmed ID";
+	final static String DB = "Database";
+	final static String PMID = "ID";
 	final static String TITLE = "Title";
 	final static String SOURCE = "Source";
 	final static String YEAR = "Year";
 	final static String AUTHORS = "Authors (separate with " + PublicationXref.AUTHOR_SEP + ")";
 	final static String QUERY = "Query PubMed";
+	final static String[] DB_OPTIONS = {"PubMed", "DOI", "ISBN"};
 
 	PublicationXref input;
+	JComboBox<Object> db;
 	JTextField pmId;
 	JTextField title;
 	JTextField source;
@@ -91,6 +95,11 @@ public class PublicationXRefDialog extends OkCancelDialog {
 	}
 
 	protected void refresh() {
+		if (input.getDb() != null) {
+			db.setSelectedIndex(java.util.Arrays.asList(DB_OPTIONS).indexOf(input.getDb()));
+		} else {	
+			db.setSelectedIndex(0);
+		}
 		setText(input.getPubmedId(), pmId);
 		setText(input.getTitle(), title);
 		setText(input.getSource(), source);
@@ -99,6 +108,7 @@ public class PublicationXRefDialog extends OkCancelDialog {
 	}
 
 	protected void okPressed() {
+		input.setDb(DB_OPTIONS[db.getSelectedIndex()]);
 		input.setPubmedId(pmId.getText().trim());
 		input.setTitle(title.getText());
 		input.setSource(source.getText());
@@ -130,6 +140,7 @@ public class PublicationXRefDialog extends OkCancelDialog {
 
 		PubMedResult pmr = pmq.getResult();
 		if(pmr != null) {
+			db.setSelectedItem(DB_OPTIONS[0]); // set pubmed
 			pmId.setText(pmr.getId()); // write the trimmed pmid to the dialog
 			title.setText(pmr.getTitle());
 			year.setText(pmr.getYear());
@@ -149,12 +160,15 @@ public class PublicationXRefDialog extends OkCancelDialog {
 		JPanel contents = new JPanel();
 		contents.setLayout(new GridBagLayout());
 
+		JLabel lblDb = new JLabel(DB);
 		JLabel lblPmId = new JLabel(PMID);
 		JLabel lblTitle = new JLabel(TITLE);
 		JLabel lblSource = new JLabel(SOURCE);
 		JLabel lblYear = new JLabel(YEAR);
 		JLabel lblAuthors = new JLabel(AUTHORS);
 
+		db = new JComboBox<Object>(DB_OPTIONS);
+		db.setEditable(true);
 		pmId = new JTextField();
 		title = new JTextField();
 		source = new JTextField();
@@ -203,6 +217,7 @@ public class PublicationXRefDialog extends OkCancelDialog {
 		c.gridy = GridBagConstraints.RELATIVE;
 		c.weightx = 0;
 		contents.add(lblPmId, c);
+		contents.add(lblDb, c);
 		contents.add(lblTitle, c);
 		contents.add(lblYear, c);
 		contents.add(lblSource, c);
@@ -212,6 +227,7 @@ public class PublicationXRefDialog extends OkCancelDialog {
 		c.fill = GridBagConstraints.HORIZONTAL;
 		c.weightx = 1;
 		contents.add(pmId, c);
+		contents.add(db, c);
 		contents.add(title, c);
 		contents.add(year, c);
 		contents.add(source, c);


### PR DESCRIPTION
- Add dropdown for PublicationXref database
- Do not delete all authors from PublicationXref
- Do not duplicate fields in PublicationXRef (#191)
- Allow empty database selection in PublicationXRef
- Insert 'NA' for bp:ID, bp:DB when empty (#190)